### PR TITLE
fix: github thumbprint changed

### DIFF
--- a/src/provider.ts
+++ b/src/provider.ts
@@ -6,7 +6,7 @@ import { Construct } from 'constructs';
 
 const DEFAULTS: { [key: string]: string } = {
   issuer: 'token.actions.githubusercontent.com',
-  thumbprint: 'a031c46782e6e6c662c2c87c76da9aa62ccabd8e',
+  thumbprint: '6938fd4d98bab03faadb97b34396831e3780aea1',
 };
 
 /**


### PR DESCRIPTION
As stated here in the [official changelog](https://github.blog/changelog/2022-01-13-github-actions-update-on-oidc-based-deployments-to-aws/) : "While renewing GitHub Actions SSL certificates, an unexpected change in the intermediate certificate authority broke workflows using Open ID Connect (OIDC) based deployment to AWS." , blueprint needs to be changed to `6938fd4d98bab03faadb97b34396831e3780aea1`